### PR TITLE
support non-JS dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
 
   return function (mako) {
     mako.postread('json', json);
-    mako.postread([ 'js', 'json' ], relative);
+    mako.predependencies([ 'js', 'json' ], relative);
     mako.predependencies('js', check);
     mako.dependencies('js', npm);
     mako.postdependencies([ 'js', 'json' ], combine);

--- a/test/fixtures/non-js-deps/index.js
+++ b/test/fixtures/non-js-deps/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./index.txt')

--- a/test/fixtures/non-js-deps/index.txt
+++ b/test/fixtures/non-js-deps/index.txt
@@ -1,0 +1,1 @@
+hi from a text file!

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,31 @@ describe('js plugin', function () {
     return assert.isRejected(builder.build(entry), 'Unexpected token');
   });
 });
+
+it('should work for non-JS dependencies', function () {
+  let entry = fixture('non-js-deps/index.js');
+  return mako()
+    .use(text('txt'))
+    .use(txt)
+    .use(plugins)
+    .build(entry)
+    .then(function (tree) {
+      let file = tree.getFile(entry);
+      assert.strictEqual(exec(file.contents), 'hi from a text file!');
+    });
+
+  /**
+   * text plugin
+   *
+   * @param {Mako} mako object
+   */
+  function txt(mako) {
+    mako.postread('txt', function (file) {
+      file.contents = `module.exports = "${file.contents.trim()}";`;
+      file.type = 'js';
+    });
+  }
+});
 /**
  * Executes the given code, returning it's return value.
  *


### PR DESCRIPTION
this changes the JS plugin from `postread` to `predependencies` to ensure that all files are processed before we start mapping. 

Before, it wouldn't run this because it was only looking for `js` and `json` extensions, so `file.id` would be `undefined` for those files.