### PR TITLE
fix support for sub-entries after browser-pack change

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ module.exports = function (options) {
       deps: file.deps || {},
       source: file.contents,
       sourceFile: config.sourceMaps ? file.id : null,
-      entry: file.isEntry()
+      entry: isRoot(file)
     };
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,7 @@ describe('js plugin', function () {
       .build(entry)
       .then(function (build) {
         let file = build.tree.getFile(fixture('subentries/index.js'));
+        assert.include(file.contents, '{},["test/fixtures/subentries/index.js"]);');
         assert.strictEqual(exec(file), 'nested');
       });
   });


### PR DESCRIPTION
not sure exactly how browser-pack works, but the update caused sub-entry code not to run anymore. this change fixes that.