### PR TITLE
sort deps before packing to fix inconsistent builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ module.exports = function (options) {
       let sourceMaps = config.sourceMaps;
       let sourceRoot = config.sourceRoot;
       let root = config.root;
-      let results = yield doPack(values(mapping), sourceMaps, sourceRoot, root);
+      let results = yield doPack(sort(values(mapping)), sourceMaps, sourceRoot, root);
 
       file.contents = results.code;
       file.sourcemap = results.map;
@@ -200,6 +200,19 @@ function extend() {
   var sources = [].slice.call(arguments);
   var args = [ Object.create(null) ].concat(sources);
   return Object.assign.apply(null, args);
+}
+
+/**
+ * Sort the dependencies
+ *
+ * @param {Array} deps
+ * @return {Array}
+ */
+
+function sort(deps) {
+  return deps.sort(function (a, b) {
+    return a.id < b.id ? -1 : 1;
+  });
 }
 
 /**


### PR DESCRIPTION
I'm running into inconsistent builds on larger projects (running `mako.build` will always return a different script). This is  because the mapping isn't sorted before going into the packer.

It doesn't do all the things that browserify does (and i'm not sure it needs to). but this is meant to be a quick fix for a really annoying problem. 

I'm not exactly sure how to test this without having access to the internal mapping object, so let me know if you have any ideas.