### PR TITLE
Address multiple entry file duplication

### DIFF
--- a/test/fixtures/multiple-entries/a.js
+++ b/test/fixtures/multiple-entries/a.js
@@ -1,0 +1,2 @@
+
+module.exports = 1 + require('./shared');

--- a/test/fixtures/multiple-entries/b.js
+++ b/test/fixtures/multiple-entries/b.js
@@ -1,0 +1,2 @@
+
+module.exports = 2 + require('./shared');

--- a/test/fixtures/multiple-entries/shared.js
+++ b/test/fixtures/multiple-entries/shared.js
@@ -1,0 +1,2 @@
+
+module.exports = 3;

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,25 @@ describe('js plugin', function () {
       });
   });
 
+  context('multiple entries', function () {
+    it('should not smush multiple entries together', function () {
+      let entries = [
+        fixture('multiple-entries/a.js'),
+        fixture('multiple-entries/b.js')
+      ];
+
+      return mako()
+        .use(plugins())
+        .build(entries)
+        .then(function (build) {
+          let a = build.tree.getFile(entries[0]);
+          assert.strictEqual(exec(a), 4);
+          let b = build.tree.getFile(entries[1]);
+          assert.strictEqual(exec(b), 5);
+        });
+    });
+  });
+
   context('circular dependencies', function () {
     it('should work with the node docs example', function () {
       let entry = fixture('circular-deps/index.js');


### PR DESCRIPTION
This changes the plugin to roll up the `mapping` property as we are processing the build tree. This removes the need to use a global `WeakMap` to track those mappings, as well as ensure that each entry only receives what it needs. (fixing #19)