### PR TITLE
Removing mako-sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ mako()
 
 Create a new plugin instance, with the following `options` available:
 
- - `sourceMaps` specify `true` for external source-maps or `"inline"` for inline source-maps (default: `false`)
- - `root` the root for the project, paths will be set relative to here (default: `pwd`)
- - `extensions` additional extensions to resolve with **in addition to** `.js` and `.json` (eg: `.coffee`)
  - `bundle` if set, should be a pathname (relative to `root`) that specifies an extra file to put shared dependencies in
+ - `extensions` additional extensions to resolve with **in addition to** `.js` and `.json` (eg: `.coffee`)
  - `resolveOptions` additional options to be passed to [resolve](https://www.npmjs.com/package/resolve)
+ - `root` the root for the project, paths will be set relative to here (default: `pwd`)
+ - `sourceMaps` specify `true` to enable source-maps (default: `false`)
+ - `sourceRoot` specifies the path used as the source map root (default: `"mako://"`)
 
 ## Dependencies
 
@@ -60,3 +61,9 @@ resolving them via [resolve](https://www.npmjs.com/package/resolve).
 During **assemble**, each _entry_ JS file will have all of it's dependencies bundled into a single
 file. Along the way, those dependencies will be _removed_ from the tree, leaving only the output
 files behind.
+
+## About Source Maps
+
+By enabling source-maps with `sourceMaps: true`, this simply generates `file.sourcemap` which is a plain
+object with the source-map metadata. Use another plugin such as [mako-sourcemaps](https://github.com/makojs/sourcemaps)
+to take this object and write it to an external file or as an inline comment.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ let insertGlobals = require('insert-module-globals');
 let path = require('path');
 let readable = require('string-to-stream');
 let resolve = require('browser-resolve');
-let sourcemaps = require('mako-sourcemaps');
 let streamify = require('stream-array');
 let syntax = require('syntax-error');
 let values = require('object-values');
@@ -57,10 +56,6 @@ module.exports = function (options) {
     }
 
     mako.postdependencies([ 'js', 'json' ], pack);
-
-    if (config.sourceMaps) {
-      mako.use(sourcemaps('js', { inline: config.sourceMaps === 'inline' }));
-    }
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "file-deps": "0.0.11",
     "https-browserify": "0.0.1",
     "insert-module-globals": "^7.0.1",
-    "mako-sourcemaps": "^0.1.0",
     "object-values": "^1.0.0",
     "os-browserify": "^0.2.0",
     "path-browserify": "0.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -233,50 +233,6 @@ describe('js plugin', function () {
     });
 
     context('.sourceMaps', function () {
-      it('should include an inline source-map', function () {
-        let entry = fixture('source-maps/index.js');
-        return mako()
-          .use(plugins({ sourceMaps: 'inline' }))
-          .build(entry)
-          .then(function (build) {
-            let code = build.tree.getFile(entry);
-            assert(convert.fromSource(code.contents), 'should have an inline source-map');
-          });
-      });
-
-      it('should not break the original code', function () {
-        let entry = fixture('source-maps/index.js');
-        return mako()
-          .use(plugins({ sourceMaps: 'inline' }))
-          .build(entry)
-          .then(function (build) {
-            let code = build.tree.getFile(entry);
-            assert.strictEqual(exec(code), 4);
-          });
-      });
-
-      it('should add an external source-map to the build', function () {
-        let entry = fixture('source-maps/index.js');
-        return mako()
-          .use(plugins({ sourceMaps: true }))
-          .build(entry)
-          .then(function (build) {
-            let map = build.tree.getFile(entry + '.map');
-            assert(convert.fromJSON(map.contents), 'should be a valid source-map file');
-          });
-      });
-
-      it('should include a link to the external source-map', function () {
-        let entry = fixture('source-maps/index.js');
-        return mako()
-          .use(plugins({ sourceMaps: true }))
-          .build(entry)
-          .then(function (build) {
-            let file = build.tree.getFile(entry);
-            assert.isTrue(convert.mapFileCommentRegex.test(file.contents));
-          });
-      });
-
       it('should not break the original code', function () {
         let entry = fixture('source-maps/index.js');
         return mako()
@@ -285,6 +241,17 @@ describe('js plugin', function () {
           .then(function (build) {
             let code = build.tree.getFile(entry);
             assert.strictEqual(exec(code), 4);
+          });
+      });
+
+      it('should generate file.sourcemap', function () {
+        let entry = fixture('source-maps/index.js');
+        return mako()
+          .use(plugins({ sourceMaps: true }))
+          .build(entry)
+          .then(function (build) {
+            let code = build.tree.getFile(entry);
+            assert(convert.fromObject(code.sourcemap), 'should have a source-map object');
           });
       });
     });


### PR DESCRIPTION
This removes mako-sourcemaps from the internals of mako-css. (fixes #23) This should instead be added by a plugin bundle or manually by a user. (mako-browser will include this as well)